### PR TITLE
Avoiding the use of Robot class

### DIFF
--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -1,200 +1,204 @@
 package com.github.joonasvali.naturalmouse.api;
 
+import java.util.Random;
+
 import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
 
-import java.util.Random;
-
 /**
- * This class should be used for creating new MouseMotion-s
- * The default instance is available via getDefault(), but can create new instance via constructor.
+ * This class should be used for creating new MouseMotion-s The default instance
+ * is available via getDefault(), but can create new instance via constructor.
  */
 public class MouseMotionFactory {
-  private static final MouseMotionFactory defaultFactory = new MouseMotionFactory();
-  private MouseMotionNature nature;
-  private Random random = new Random();
+	private static MouseMotionFactory defaultFactory;
+	private MouseMotionNature nature;
+	private Random random = new Random();
 
-  public MouseMotionFactory(MouseMotionNature nature) {
-    this.nature = nature;
-  }
+	public MouseMotionFactory(final MouseMotionNature nature) {
+		this.nature = nature;
+	}
 
-  public MouseMotionFactory() {
-    this(new DefaultMouseMotionNature());
-  }
+	public MouseMotionFactory() {
+		this(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * Builds the MouseMotion, which can be executed instantly or saved for later.
-   *
-   * @param xDest the end position x-coordinate for the mouse
-   * @param yDest the end position y-coordinate for the mouse
-   * @return the MouseMotion which can be executed instantly or saved for later. (Mouse will be moved from its
-   * current position, not from the position where mouse was during building.)
-   */
-  public MouseMotion build(int xDest, int yDest) {
-    return new MouseMotion(nature, random, xDest, yDest);
-  }
+	/**
+	 * Builds the MouseMotion, which can be executed instantly or saved for later.
+	 *
+	 * @param xDest the end position x-coordinate for the mouse
+	 * @param yDest the end position y-coordinate for the mouse
+	 * @return the MouseMotion which can be executed instantly or saved for later.
+	 *         (Mouse will be moved from its current position, not from the position
+	 *         where mouse was during building.)
+	 */
+	public MouseMotion build(final int xDest, final int yDest) {
+		return new MouseMotion(nature, random, xDest, yDest);
+	}
 
-  /**
-   * Start moving the mouse to specified location. Blocks until done.
-   *
-   * @param xDest the end position x-coordinate for the mouse
-   * @param yDest the end position y-coordinate for the mouse
-   * @throws InterruptedException if something interrupts the thread.
-   */
-  public void move(int xDest, int yDest) throws InterruptedException {
-    build(xDest, yDest).move();
-  }
+	/**
+	 * Start moving the mouse to specified location. Blocks until done.
+	 *
+	 * @param xDest the end position x-coordinate for the mouse
+	 * @param yDest the end position y-coordinate for the mouse
+	 * @throws InterruptedException if something interrupts the thread.
+	 */
+	public void move(final int xDest, final int yDest) throws InterruptedException {
+		build(xDest, yDest).move();
+	}
 
-  /**
-   * Get the default factory implementation.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory getDefault() {
-    return defaultFactory;
-  }
+	/**
+	 * Get the default factory implementation.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory getDefault() {
+		if (defaultFactory == null) {
+			defaultFactory = new MouseMotionFactory();
+		}
+		return defaultFactory;
+	}
 
-  /**
-   * see {@link MouseMotionNature#getSystemCalls()}
-   *
-   * @return the systemcalls
-   */
-  public SystemCalls getSystemCalls() {
-    return nature.getSystemCalls();
-  }
+	/**
+	 * see {@link MouseMotionNature#getSystemCalls()}
+	 *
+	 * @return the systemcalls
+	 */
+	public SystemCalls getSystemCalls() {
+		return nature.getSystemCalls();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
-   *
-   * @param systemCalls the systemcalls
-   */
-  public void setSystemCalls(SystemCalls systemCalls) {
-    nature.setSystemCalls(systemCalls);
-  }
+	/**
+	 * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
+	 *
+	 * @param systemCalls the systemcalls
+	 */
+	public void setSystemCalls(final SystemCalls systemCalls) {
+		nature.setSystemCalls(systemCalls);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getDeviationProvider()}
-   *
-   * @return the deviation provider
-   */
-  public DeviationProvider getDeviationProvider() {
-    return nature.getDeviationProvider();
-  }
+	/**
+	 * see {@link MouseMotionNature#getDeviationProvider()}
+	 *
+	 * @return the deviation provider
+	 */
+	public DeviationProvider getDeviationProvider() {
+		return nature.getDeviationProvider();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
-   *
-   * @param deviationProvider the deviation provider
-   */
-  public void setDeviationProvider(DeviationProvider deviationProvider) {
-    nature.setDeviationProvider(deviationProvider);
-  }
+	/**
+	 * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
+	 *
+	 * @param deviationProvider the deviation provider
+	 */
+	public void setDeviationProvider(final DeviationProvider deviationProvider) {
+		nature.setDeviationProvider(deviationProvider);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getNoiseProvider()}
-   *
-   * @return the noise provider
-   */
-  public NoiseProvider getNoiseProvider() {
-    return nature.getNoiseProvider();
-  }
+	/**
+	 * see {@link MouseMotionNature#getNoiseProvider()}
+	 *
+	 * @return the noise provider
+	 */
+	public NoiseProvider getNoiseProvider() {
+		return nature.getNoiseProvider();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
-   *
-   * @param noiseProvider the noise provider
-   */
-  public void setNoiseProvider(NoiseProvider noiseProvider) {
-    nature.setNoiseProvider(noiseProvider);
-  }
+	/**
+	 * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
+	 *
+	 * @param noiseProvider the noise provider
+	 */
+	public void setNoiseProvider(final NoiseProvider noiseProvider) {
+		nature.setNoiseProvider(noiseProvider);
+	}
 
-  /**
-   * Get the random used whenever randomized behavior is needed in MouseMotion
-   *
-   * @return the random
-   */
-  public Random getRandom() {
-    return random;
-  }
+	/**
+	 * Get the random used whenever randomized behavior is needed in MouseMotion
+	 *
+	 * @return the random
+	 */
+	public Random getRandom() {
+		return random;
+	}
 
-  /**
-   * Set the random used whenever randomized behavior is needed in MouseMotion
-   *
-   * @param random the random
-   */
-  public void setRandom(Random random) {
-    this.random = random;
-  }
+	/**
+	 * Set the random used whenever randomized behavior is needed in MouseMotion
+	 *
+	 * @param random the random
+	 */
+	public void setRandom(final Random random) {
+		this.random = random;
+	}
 
-  /**
-   * see {@link MouseMotionNature#getMouseInfo()}
-   *
-   * @return the mouseInfo
-   */
-  public MouseInfoAccessor getMouseInfo() {
-    return nature.getMouseInfo();
-  }
+	/**
+	 * see {@link MouseMotionNature#getMouseInfo()}
+	 *
+	 * @return the mouseInfo
+	 */
+	public MouseInfoAccessor getMouseInfo() {
+		return nature.getMouseInfo();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
-   *
-   * @param mouseInfo the mouseInfo
-   */
-  public void setMouseInfo(MouseInfoAccessor mouseInfo) {
-    nature.setMouseInfo(mouseInfo);
-  }
+	/**
+	 * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
+	 *
+	 * @param mouseInfo the mouseInfo
+	 */
+	public void setMouseInfo(final MouseInfoAccessor mouseInfo) {
+		nature.setMouseInfo(mouseInfo);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getSpeedManager()}
-   *
-   * @return the manager
-   */
-  public SpeedManager getSpeedManager() {
-    return nature.getSpeedManager();
-  }
+	/**
+	 * see {@link MouseMotionNature#getSpeedManager()}
+	 *
+	 * @return the manager
+	 */
+	public SpeedManager getSpeedManager() {
+		return nature.getSpeedManager();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
-   *
-   * @param speedManager the manager
-   */
-  public void setSpeedManager(SpeedManager speedManager) {
-    nature.setSpeedManager(speedManager);
-  }
+	/**
+	 * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
+	 *
+	 * @param speedManager the manager
+	 */
+	public void setSpeedManager(final SpeedManager speedManager) {
+		nature.setSpeedManager(speedManager);
+	}
 
-  /**
-   * The Nature of mousemotion covers all aspects how the mouse is moved.
-   *
-   * @return the nature
-   */
-  public MouseMotionNature getNature() {
-    return nature;
-  }
+	/**
+	 * The Nature of mousemotion covers all aspects how the mouse is moved.
+	 *
+	 * @return the nature
+	 */
+	public MouseMotionNature getNature() {
+		return nature;
+	}
 
-  /**
-   * The Nature of mousemotion covers all aspects how the mouse is moved.
-   *
-   * @param nature the new nature
-   */
-  public void setNature(MouseMotionNature nature) {
-    this.nature = nature;
-  }
+	/**
+	 * The Nature of mousemotion covers all aspects how the mouse is moved.
+	 *
+	 * @param nature the new nature
+	 */
+	public void setNature(final MouseMotionNature nature) {
+		this.nature = nature;
+	}
 
-  /**
-   * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
-   *
-   * @param manager the manager
-   */
-  public void setOvershootManager(OvershootManager manager) {
-    nature.setOvershootManager(manager);
-  }
+	/**
+	 * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
+	 *
+	 * @param manager the manager
+	 */
+	public void setOvershootManager(final OvershootManager manager) {
+		nature.setOvershootManager(manager);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getOvershootManager()}
-   *
-   * @return the manager
-   */
-  public OvershootManager getOvershootManager() {
-    return nature.getOvershootManager();
-  }
+	/**
+	 * see {@link MouseMotionNature#getOvershootManager()}
+	 *
+	 * @return the manager
+	 */
+	public OvershootManager getOvershootManager() {
+		return nature.getOvershootManager();
+	}
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
@@ -1,35 +1,46 @@
 package com.github.joonasvali.naturalmouse.support;
 
-import java.awt.*;
-import java.util.Random;
-
 import static com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER;
 import static com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER;
 
+import java.awt.AWTException;
+import java.awt.Robot;
+import java.util.Random;
+
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
+
 public class DefaultMouseMotionNature extends MouseMotionNature {
 
-  public static final int TIME_TO_STEPS_DIVIDER = 8;
-  public static final int MIN_STEPS = 10;
-  public static final int EFFECT_FADE_STEPS = 15;
-  public static final int REACTION_TIME_BASE_MS = 20;
-  public static final int REACTION_TIME_VARIATION_MS = 120;
+	public static final int TIME_TO_STEPS_DIVIDER = 8;
+	public static final int MIN_STEPS = 10;
+	public static final int EFFECT_FADE_STEPS = 15;
+	public static final int REACTION_TIME_BASE_MS = 20;
+	public static final int REACTION_TIME_VARIATION_MS = 120;
 
-  public DefaultMouseMotionNature() {
-    try {
-      setSystemCalls(new DefaultSystemCalls(new Robot()));
-    } catch (AWTException e) {
-      throw new RuntimeException(e);
-    }
+	public DefaultMouseMotionNature(final SystemCalls systemCalls) {
+		setSystemCalls(systemCalls);
+		setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
+		setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
+		setSpeedManager(new DefaultSpeedManager());
+		setOvershootManager(new DefaultOvershootManager(new Random()));
+		setEffectFadeSteps(EFFECT_FADE_STEPS);
+		setMinSteps(MIN_STEPS);
+		setMouseInfo(new DefaultMouseInfoAccessor());
+		setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
+		setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
+		setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
+	}
 
-    setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
-    setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
-    setSpeedManager(new DefaultSpeedManager());
-    setOvershootManager(new DefaultOvershootManager(new Random()));
-    setEffectFadeSteps(EFFECT_FADE_STEPS);
-    setMinSteps(MIN_STEPS);
-    setMouseInfo(new DefaultMouseInfoAccessor());
-    setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
-    setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
-    setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
-  }
+	public DefaultMouseMotionNature() {
+		this(new DefaultSystemCalls(getRobot()));
+
+	}
+
+	private static Robot getRobot() {
+		try {
+			return new Robot();
+		} catch (final AWTException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -1,7 +1,12 @@
 package com.github.joonasvali.naturalmouse.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
 import com.github.joonasvali.naturalmouse.api.SpeedManager;
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
 import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider;
 import com.github.joonasvali.naturalmouse.support.DefaultOvershootManager;
@@ -11,166 +16,169 @@ import com.github.joonasvali.naturalmouse.support.Flow;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 public class FactoryTemplates {
-  /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
-   * Low speed, variating flow, lots of noise in movement.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createGrannyMotionFactory() {
-    return createGrannyMotionFactory(new DefaultMouseMotionNature());
-  }
+	/**
+	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
+	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createGrannyMotionFactory() {
+		return createGrannyMotionFactory(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
-   * Low speed, variating flow, lots of noise in movement.
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createGrannyMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.jaggedFlow()),
-        new Flow(FlowTemplates.random()),
-        new Flow(FlowTemplates.interruptedFlow()),
-        new Flow(FlowTemplates.interruptedFlow2()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.stoppingFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
-    factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
-    factory.getNature().setReactionTimeBaseMs(100);
+	/**
+	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
+	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createGrannyMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(
+				Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
+						new Flow(FlowTemplates.interruptedFlow()), new Flow(FlowTemplates.interruptedFlow2()),
+						new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.stoppingFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
+		factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
+		factory.getNature().setReactionTimeBaseMs(100);
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(3);
-    overshootManager.setMinDistanceForOvershoots(3);
-    overshootManager.setMinOvershootMovementMs(400);
-    overshootManager.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
-    overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(3);
+		overshootManager.setMinDistanceForOvershoots(3);
+		overshootManager.setMinOvershootMovementMs(400);
+		overshootManager
+				.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
+		overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
 
-    factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
-    manager.setMouseMovementBaseTimeMs(1000);
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+		factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
+		manager.setMouseMovementBaseTimeMs(1000);
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-  /**
-   * <h1>Robotic fluent movement.</h1>
-   * Custom speed, constant movement, no mistakes, no overshoots.
-   *
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
-   * @return the factory
-   */
-  public static MouseMotionFactory createDemoRobotMotionFactory(long motionTimeMsPer100Pixels) {
-    return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
-  }
+	/**
+	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+	 * mistakes, no overshoots.
+	 *
+	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+	 *                                 pixels of travelling
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createDemoRobotMotionFactory(final long motionTimeMsPer100Pixels) {
+		return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
+	}
 
-  /**
-   * <h1>Robotic fluent movement.</h1>
-   * Custom speed, constant movement, no mistakes, no overshoots.
-   *
-   * @param nature the nature for the template to be configured on
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
-   * @return the factory
-   */
-  public static MouseMotionFactory createDemoRobotMotionFactory(
-      MouseMotionNature nature, long motionTimeMsPer100Pixels
-  ) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final Flow flow = new Flow(FlowTemplates.constantSpeed());
-    double timePerPixel = motionTimeMsPer100Pixels / 100d;
-    SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
-    factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
-    factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
+	/**
+	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+	 * mistakes, no overshoots.
+	 *
+	 * @param nature                   the nature for the template to be configured
+	 *                                 on
+	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+	 *                                 pixels of travelling
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createDemoRobotMotionFactory(final MouseMotionNature nature,
+			final long motionTimeMsPer100Pixels) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final Flow flow = new Flow(FlowTemplates.constantSpeed());
+		final double timePerPixel = motionTimeMsPer100Pixels / 100d;
+		final SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
+		factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
+		factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(0);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(0);
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-  /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
-   * Quick movement, low noise, some deviation, lots of overshoots.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createFastGamerMotionFactory() {
-    return createFastGamerMotionFactory(new DefaultMouseMotionNature());
-  }
+	/**
+	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+	 * low noise, some deviation, lots of overshoots.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createFastGamerMotionFactory() {
+		return createFastGamerMotionFactory(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
-   * Quick movement, low noise, some deviation, lots of overshoots.
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createFastGamerMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.variatingFlow()),
-        new Flow(FlowTemplates.slowStartupFlow()),
-        new Flow(FlowTemplates.slowStartup2Flow()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.jaggedFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-    factory.getNature().setReactionTimeVariationMs(100);
-    manager.setMouseMovementBaseTimeMs(250);
+	/**
+	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+	 * low noise, some deviation, lots of overshoots.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createFastGamerMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
+				new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
+				new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.jaggedFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(
+				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+		factory.getNature().setReactionTimeVariationMs(100);
+		manager.setMouseMovementBaseTimeMs(250);
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(4);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(4);
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
-  /**
-   * <h1>Standard computer user with average speed and movement mistakes</h1>
-   * medium noise, medium speed, medium noise and deviation.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory() {
-    return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
-  }
-  /**
-   * <h1>Standard computer user with average speed and movement mistakes</h1>
-   * medium noise, medium speed, medium noise and deviation.
-   *
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.variatingFlow()),
-        new Flow(FlowTemplates.interruptedFlow()),
-        new Flow(FlowTemplates.interruptedFlow2()),
-        new Flow(FlowTemplates.slowStartupFlow()),
-        new Flow(FlowTemplates.slowStartup2Flow()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.jaggedFlow()),
-        new Flow(FlowTemplates.stoppingFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-    factory.getNature().setReactionTimeVariationMs(110);
-    manager.setMouseMovementBaseTimeMs(400);
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(4);
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory() {
+		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
+	}
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @param systemCalls System call provider
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory(final SystemCalls systemCalls) {
+		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
+	}
+
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(
+				Arrays.asList(new Flow(FlowTemplates.variatingFlow()), new Flow(FlowTemplates.interruptedFlow()),
+						new Flow(FlowTemplates.interruptedFlow2()), new Flow(FlowTemplates.slowStartupFlow()),
+						new Flow(FlowTemplates.slowStartup2Flow()), new Flow(FlowTemplates.adjustingFlow()),
+						new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.stoppingFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(
+				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+		factory.getNature().setReactionTimeVariationMs(110);
+		manager.setMouseMovementBaseTimeMs(400);
+
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(4);
+
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 }


### PR DESCRIPTION
We are mostly interested in points generated by algorithm. We take the points and drive the mouse in a different way.

Implementation was referring Robot class which was throwing the exception about headless environment as GUI is not available.

The change creates Robot instance only when needed