### PR TITLE
Avoid robot class initialization when not needed

### DIFF
--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -1,204 +1,204 @@
 package com.github.joonasvali.naturalmouse.api;
 
-import java.util.Random;
-
 import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
+
+import java.util.Random;
 
 /**
  * This class should be used for creating new MouseMotion-s The default instance
  * is available via getDefault(), but can create new instance via constructor.
  */
 public class MouseMotionFactory {
-	private static MouseMotionFactory defaultFactory;
-	private MouseMotionNature nature;
-	private Random random = new Random();
+  private static MouseMotionFactory defaultFactory;
+  private MouseMotionNature nature;
+  private Random random = new Random();
 
-	public MouseMotionFactory(final MouseMotionNature nature) {
-		this.nature = nature;
-	}
+  public MouseMotionFactory(final MouseMotionNature nature) {
+    this.nature = nature;
+  }
 
-	public MouseMotionFactory() {
-		this(new DefaultMouseMotionNature());
-	}
+  public MouseMotionFactory() {
+    this(new DefaultMouseMotionNature());
+  }
 
-	/**
-	 * Builds the MouseMotion, which can be executed instantly or saved for later.
-	 *
-	 * @param xDest the end position x-coordinate for the mouse
-	 * @param yDest the end position y-coordinate for the mouse
-	 * @return the MouseMotion which can be executed instantly or saved for later.
-	 *         (Mouse will be moved from its current position, not from the position
-	 *         where mouse was during building.)
-	 */
-	public MouseMotion build(final int xDest, final int yDest) {
-		return new MouseMotion(nature, random, xDest, yDest);
-	}
+  /**
+   * Builds the MouseMotion, which can be executed instantly or saved for later.
+   *
+   * @param xDest the end position x-coordinate for the mouse
+   * @param yDest the end position y-coordinate for the mouse
+   * @return the MouseMotion which can be executed instantly or saved for later.
+   * (Mouse will be moved from its current position, not from the position
+   * where mouse was during building.)
+   */
+  public MouseMotion build(final int xDest, final int yDest) {
+    return new MouseMotion(nature, random, xDest, yDest);
+  }
 
-	/**
-	 * Start moving the mouse to specified location. Blocks until done.
-	 *
-	 * @param xDest the end position x-coordinate for the mouse
-	 * @param yDest the end position y-coordinate for the mouse
-	 * @throws InterruptedException if something interrupts the thread.
-	 */
-	public void move(final int xDest, final int yDest) throws InterruptedException {
-		build(xDest, yDest).move();
-	}
+  /**
+   * Start moving the mouse to specified location. Blocks until done.
+   *
+   * @param xDest the end position x-coordinate for the mouse
+   * @param yDest the end position y-coordinate for the mouse
+   * @throws InterruptedException if something interrupts the thread.
+   */
+  public void move(final int xDest, final int yDest) throws InterruptedException {
+    build(xDest, yDest).move();
+  }
 
-	/**
-	 * Get the default factory implementation.
-	 *
-	 * @return the factory
-	 */
-	public static MouseMotionFactory getDefault() {
-		if (defaultFactory == null) {
-			defaultFactory = new MouseMotionFactory();
-		}
-		return defaultFactory;
-	}
+  /**
+   * Get the default factory implementation.
+   *
+   * @return the factory
+   */
+  public static MouseMotionFactory getDefault() {
+    if (defaultFactory == null) {
+      defaultFactory = new MouseMotionFactory();
+    }
+    return defaultFactory;
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getSystemCalls()}
-	 *
-	 * @return the systemcalls
-	 */
-	public SystemCalls getSystemCalls() {
-		return nature.getSystemCalls();
-	}
+  /**
+   * see {@link MouseMotionNature#getSystemCalls()}
+   *
+   * @return the systemcalls
+   */
+  public SystemCalls getSystemCalls() {
+    return nature.getSystemCalls();
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
-	 *
-	 * @param systemCalls the systemcalls
-	 */
-	public void setSystemCalls(final SystemCalls systemCalls) {
-		nature.setSystemCalls(systemCalls);
-	}
+  /**
+   * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
+   *
+   * @param systemCalls the systemcalls
+   */
+  public void setSystemCalls(final SystemCalls systemCalls) {
+    nature.setSystemCalls(systemCalls);
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getDeviationProvider()}
-	 *
-	 * @return the deviation provider
-	 */
-	public DeviationProvider getDeviationProvider() {
-		return nature.getDeviationProvider();
-	}
+  /**
+   * see {@link MouseMotionNature#getDeviationProvider()}
+   *
+   * @return the deviation provider
+   */
+  public DeviationProvider getDeviationProvider() {
+    return nature.getDeviationProvider();
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
-	 *
-	 * @param deviationProvider the deviation provider
-	 */
-	public void setDeviationProvider(final DeviationProvider deviationProvider) {
-		nature.setDeviationProvider(deviationProvider);
-	}
+  /**
+   * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
+   *
+   * @param deviationProvider the deviation provider
+   */
+  public void setDeviationProvider(final DeviationProvider deviationProvider) {
+    nature.setDeviationProvider(deviationProvider);
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getNoiseProvider()}
-	 *
-	 * @return the noise provider
-	 */
-	public NoiseProvider getNoiseProvider() {
-		return nature.getNoiseProvider();
-	}
+  /**
+   * see {@link MouseMotionNature#getNoiseProvider()}
+   *
+   * @return the noise provider
+   */
+  public NoiseProvider getNoiseProvider() {
+    return nature.getNoiseProvider();
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
-	 *
-	 * @param noiseProvider the noise provider
-	 */
-	public void setNoiseProvider(final NoiseProvider noiseProvider) {
-		nature.setNoiseProvider(noiseProvider);
-	}
+  /**
+   * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
+   *
+   * @param noiseProvider the noise provider
+   */
+  public void setNoiseProvider(final NoiseProvider noiseProvider) {
+    nature.setNoiseProvider(noiseProvider);
+  }
 
-	/**
-	 * Get the random used whenever randomized behavior is needed in MouseMotion
-	 *
-	 * @return the random
-	 */
-	public Random getRandom() {
-		return random;
-	}
+  /**
+   * Get the random used whenever randomized behavior is needed in MouseMotion
+   *
+   * @return the random
+   */
+  public Random getRandom() {
+    return random;
+  }
 
-	/**
-	 * Set the random used whenever randomized behavior is needed in MouseMotion
-	 *
-	 * @param random the random
-	 */
-	public void setRandom(final Random random) {
-		this.random = random;
-	}
+  /**
+   * Set the random used whenever randomized behavior is needed in MouseMotion
+   *
+   * @param random the random
+   */
+  public void setRandom(final Random random) {
+    this.random = random;
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getMouseInfo()}
-	 *
-	 * @return the mouseInfo
-	 */
-	public MouseInfoAccessor getMouseInfo() {
-		return nature.getMouseInfo();
-	}
+  /**
+   * see {@link MouseMotionNature#getMouseInfo()}
+   *
+   * @return the mouseInfo
+   */
+  public MouseInfoAccessor getMouseInfo() {
+    return nature.getMouseInfo();
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
-	 *
-	 * @param mouseInfo the mouseInfo
-	 */
-	public void setMouseInfo(final MouseInfoAccessor mouseInfo) {
-		nature.setMouseInfo(mouseInfo);
-	}
+  /**
+   * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
+   *
+   * @param mouseInfo the mouseInfo
+   */
+  public void setMouseInfo(final MouseInfoAccessor mouseInfo) {
+    nature.setMouseInfo(mouseInfo);
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getSpeedManager()}
-	 *
-	 * @return the manager
-	 */
-	public SpeedManager getSpeedManager() {
-		return nature.getSpeedManager();
-	}
+  /**
+   * see {@link MouseMotionNature#getSpeedManager()}
+   *
+   * @return the manager
+   */
+  public SpeedManager getSpeedManager() {
+    return nature.getSpeedManager();
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
-	 *
-	 * @param speedManager the manager
-	 */
-	public void setSpeedManager(final SpeedManager speedManager) {
-		nature.setSpeedManager(speedManager);
-	}
+  /**
+   * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
+   *
+   * @param speedManager the manager
+   */
+  public void setSpeedManager(final SpeedManager speedManager) {
+    nature.setSpeedManager(speedManager);
+  }
 
-	/**
-	 * The Nature of mousemotion covers all aspects how the mouse is moved.
-	 *
-	 * @return the nature
-	 */
-	public MouseMotionNature getNature() {
-		return nature;
-	}
+  /**
+   * The Nature of mousemotion covers all aspects how the mouse is moved.
+   *
+   * @return the nature
+   */
+  public MouseMotionNature getNature() {
+    return nature;
+  }
 
-	/**
-	 * The Nature of mousemotion covers all aspects how the mouse is moved.
-	 *
-	 * @param nature the new nature
-	 */
-	public void setNature(final MouseMotionNature nature) {
-		this.nature = nature;
-	}
+  /**
+   * The Nature of mousemotion covers all aspects how the mouse is moved.
+   *
+   * @param nature the new nature
+   */
+  public void setNature(final MouseMotionNature nature) {
+    this.nature = nature;
+  }
 
-	/**
-	 * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
-	 *
-	 * @param manager the manager
-	 */
-	public void setOvershootManager(final OvershootManager manager) {
-		nature.setOvershootManager(manager);
-	}
+  /**
+   * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
+   *
+   * @param manager the manager
+   */
+  public void setOvershootManager(final OvershootManager manager) {
+    nature.setOvershootManager(manager);
+  }
 
-	/**
-	 * see {@link MouseMotionNature#getOvershootManager()}
-	 *
-	 * @return the manager
-	 */
-	public OvershootManager getOvershootManager() {
-		return nature.getOvershootManager();
-	}
+  /**
+   * see {@link MouseMotionNature#getOvershootManager()}
+   *
+   * @return the manager
+   */
+  public OvershootManager getOvershootManager() {
+    return nature.getOvershootManager();
+  }
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -1,200 +1,204 @@
 package com.github.joonasvali.naturalmouse.api;
 
+import java.util.Random;
+
 import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
 
-import java.util.Random;
-
 /**
- * This class should be used for creating new MouseMotion-s
- * The default instance is available via getDefault(), but can create new instance via constructor.
+ * This class should be used for creating new MouseMotion-s The default instance
+ * is available via getDefault(), but can create new instance via constructor.
  */
 public class MouseMotionFactory {
-  private static final MouseMotionFactory defaultFactory = new MouseMotionFactory();
-  private MouseMotionNature nature;
-  private Random random = new Random();
+	private static MouseMotionFactory defaultFactory;
+	private MouseMotionNature nature;
+	private Random random = new Random();
 
-  public MouseMotionFactory(MouseMotionNature nature) {
-    this.nature = nature;
-  }
+	public MouseMotionFactory(final MouseMotionNature nature) {
+		this.nature = nature;
+	}
 
-  public MouseMotionFactory() {
-    this(new DefaultMouseMotionNature());
-  }
+	public MouseMotionFactory() {
+		this(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * Builds the MouseMotion, which can be executed instantly or saved for later.
-   *
-   * @param xDest the end position x-coordinate for the mouse
-   * @param yDest the end position y-coordinate for the mouse
-   * @return the MouseMotion which can be executed instantly or saved for later. (Mouse will be moved from its
-   * current position, not from the position where mouse was during building.)
-   */
-  public MouseMotion build(int xDest, int yDest) {
-    return new MouseMotion(nature, random, xDest, yDest);
-  }
+	/**
+	 * Builds the MouseMotion, which can be executed instantly or saved for later.
+	 *
+	 * @param xDest the end position x-coordinate for the mouse
+	 * @param yDest the end position y-coordinate for the mouse
+	 * @return the MouseMotion which can be executed instantly or saved for later.
+	 *         (Mouse will be moved from its current position, not from the position
+	 *         where mouse was during building.)
+	 */
+	public MouseMotion build(final int xDest, final int yDest) {
+		return new MouseMotion(nature, random, xDest, yDest);
+	}
 
-  /**
-   * Start moving the mouse to specified location. Blocks until done.
-   *
-   * @param xDest the end position x-coordinate for the mouse
-   * @param yDest the end position y-coordinate for the mouse
-   * @throws InterruptedException if something interrupts the thread.
-   */
-  public void move(int xDest, int yDest) throws InterruptedException {
-    build(xDest, yDest).move();
-  }
+	/**
+	 * Start moving the mouse to specified location. Blocks until done.
+	 *
+	 * @param xDest the end position x-coordinate for the mouse
+	 * @param yDest the end position y-coordinate for the mouse
+	 * @throws InterruptedException if something interrupts the thread.
+	 */
+	public void move(final int xDest, final int yDest) throws InterruptedException {
+		build(xDest, yDest).move();
+	}
 
-  /**
-   * Get the default factory implementation.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory getDefault() {
-    return defaultFactory;
-  }
+	/**
+	 * Get the default factory implementation.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory getDefault() {
+		if (defaultFactory == null) {
+			defaultFactory = new MouseMotionFactory();
+		}
+		return defaultFactory;
+	}
 
-  /**
-   * see {@link MouseMotionNature#getSystemCalls()}
-   *
-   * @return the systemcalls
-   */
-  public SystemCalls getSystemCalls() {
-    return nature.getSystemCalls();
-  }
+	/**
+	 * see {@link MouseMotionNature#getSystemCalls()}
+	 *
+	 * @return the systemcalls
+	 */
+	public SystemCalls getSystemCalls() {
+		return nature.getSystemCalls();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
-   *
-   * @param systemCalls the systemcalls
-   */
-  public void setSystemCalls(SystemCalls systemCalls) {
-    nature.setSystemCalls(systemCalls);
-  }
+	/**
+	 * see {@link MouseMotionNature#setSystemCalls(SystemCalls)}
+	 *
+	 * @param systemCalls the systemcalls
+	 */
+	public void setSystemCalls(final SystemCalls systemCalls) {
+		nature.setSystemCalls(systemCalls);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getDeviationProvider()}
-   *
-   * @return the deviation provider
-   */
-  public DeviationProvider getDeviationProvider() {
-    return nature.getDeviationProvider();
-  }
+	/**
+	 * see {@link MouseMotionNature#getDeviationProvider()}
+	 *
+	 * @return the deviation provider
+	 */
+	public DeviationProvider getDeviationProvider() {
+		return nature.getDeviationProvider();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
-   *
-   * @param deviationProvider the deviation provider
-   */
-  public void setDeviationProvider(DeviationProvider deviationProvider) {
-    nature.setDeviationProvider(deviationProvider);
-  }
+	/**
+	 * see {@link MouseMotionNature#setDeviationProvider(DeviationProvider)}
+	 *
+	 * @param deviationProvider the deviation provider
+	 */
+	public void setDeviationProvider(final DeviationProvider deviationProvider) {
+		nature.setDeviationProvider(deviationProvider);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getNoiseProvider()}
-   *
-   * @return the noise provider
-   */
-  public NoiseProvider getNoiseProvider() {
-    return nature.getNoiseProvider();
-  }
+	/**
+	 * see {@link MouseMotionNature#getNoiseProvider()}
+	 *
+	 * @return the noise provider
+	 */
+	public NoiseProvider getNoiseProvider() {
+		return nature.getNoiseProvider();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
-   *
-   * @param noiseProvider the noise provider
-   */
-  public void setNoiseProvider(NoiseProvider noiseProvider) {
-    nature.setNoiseProvider(noiseProvider);
-  }
+	/**
+	 * see {@link MouseMotionNature#setNoiseProvider(NoiseProvider)}}
+	 *
+	 * @param noiseProvider the noise provider
+	 */
+	public void setNoiseProvider(final NoiseProvider noiseProvider) {
+		nature.setNoiseProvider(noiseProvider);
+	}
 
-  /**
-   * Get the random used whenever randomized behavior is needed in MouseMotion
-   *
-   * @return the random
-   */
-  public Random getRandom() {
-    return random;
-  }
+	/**
+	 * Get the random used whenever randomized behavior is needed in MouseMotion
+	 *
+	 * @return the random
+	 */
+	public Random getRandom() {
+		return random;
+	}
 
-  /**
-   * Set the random used whenever randomized behavior is needed in MouseMotion
-   *
-   * @param random the random
-   */
-  public void setRandom(Random random) {
-    this.random = random;
-  }
+	/**
+	 * Set the random used whenever randomized behavior is needed in MouseMotion
+	 *
+	 * @param random the random
+	 */
+	public void setRandom(final Random random) {
+		this.random = random;
+	}
 
-  /**
-   * see {@link MouseMotionNature#getMouseInfo()}
-   *
-   * @return the mouseInfo
-   */
-  public MouseInfoAccessor getMouseInfo() {
-    return nature.getMouseInfo();
-  }
+	/**
+	 * see {@link MouseMotionNature#getMouseInfo()}
+	 *
+	 * @return the mouseInfo
+	 */
+	public MouseInfoAccessor getMouseInfo() {
+		return nature.getMouseInfo();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
-   *
-   * @param mouseInfo the mouseInfo
-   */
-  public void setMouseInfo(MouseInfoAccessor mouseInfo) {
-    nature.setMouseInfo(mouseInfo);
-  }
+	/**
+	 * see {@link MouseMotionNature#setMouseInfo(MouseInfoAccessor)}
+	 *
+	 * @param mouseInfo the mouseInfo
+	 */
+	public void setMouseInfo(final MouseInfoAccessor mouseInfo) {
+		nature.setMouseInfo(mouseInfo);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getSpeedManager()}
-   *
-   * @return the manager
-   */
-  public SpeedManager getSpeedManager() {
-    return nature.getSpeedManager();
-  }
+	/**
+	 * see {@link MouseMotionNature#getSpeedManager()}
+	 *
+	 * @return the manager
+	 */
+	public SpeedManager getSpeedManager() {
+		return nature.getSpeedManager();
+	}
 
-  /**
-   * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
-   *
-   * @param speedManager the manager
-   */
-  public void setSpeedManager(SpeedManager speedManager) {
-    nature.setSpeedManager(speedManager);
-  }
+	/**
+	 * see {@link MouseMotionNature#setSpeedManager(SpeedManager)}
+	 *
+	 * @param speedManager the manager
+	 */
+	public void setSpeedManager(final SpeedManager speedManager) {
+		nature.setSpeedManager(speedManager);
+	}
 
-  /**
-   * The Nature of mousemotion covers all aspects how the mouse is moved.
-   *
-   * @return the nature
-   */
-  public MouseMotionNature getNature() {
-    return nature;
-  }
+	/**
+	 * The Nature of mousemotion covers all aspects how the mouse is moved.
+	 *
+	 * @return the nature
+	 */
+	public MouseMotionNature getNature() {
+		return nature;
+	}
 
-  /**
-   * The Nature of mousemotion covers all aspects how the mouse is moved.
-   *
-   * @param nature the new nature
-   */
-  public void setNature(MouseMotionNature nature) {
-    this.nature = nature;
-  }
+	/**
+	 * The Nature of mousemotion covers all aspects how the mouse is moved.
+	 *
+	 * @param nature the new nature
+	 */
+	public void setNature(final MouseMotionNature nature) {
+		this.nature = nature;
+	}
 
-  /**
-   * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
-   *
-   * @param manager the manager
-   */
-  public void setOvershootManager(OvershootManager manager) {
-    nature.setOvershootManager(manager);
-  }
+	/**
+	 * see {@link MouseMotionNature#setOvershootManager(OvershootManager)}
+	 *
+	 * @param manager the manager
+	 */
+	public void setOvershootManager(final OvershootManager manager) {
+		nature.setOvershootManager(manager);
+	}
 
-  /**
-   * see {@link MouseMotionNature#getOvershootManager()}
-   *
-   * @return the manager
-   */
-  public OvershootManager getOvershootManager() {
-    return nature.getOvershootManager();
-  }
+	/**
+	 * see {@link MouseMotionNature#getOvershootManager()}
+	 *
+	 * @return the manager
+	 */
+	public OvershootManager getOvershootManager() {
+		return nature.getOvershootManager();
+	}
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -4,13 +4,14 @@ import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
 
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * This class should be used for creating new MouseMotion-s The default instance
+ * This class should be used for creating new `MouseMotion`s. The default instance
  * is available via getDefault(), but can create new instance via constructor.
  */
 public class MouseMotionFactory {
-  private static MouseMotionFactory defaultFactory;
+  private static AtomicReference<MouseMotionFactory> defaultFactory = new AtomicReference<>();
   private MouseMotionNature nature;
   private Random random = new Random();
 
@@ -52,10 +53,10 @@ public class MouseMotionFactory {
    * @return the factory
    */
   public static MouseMotionFactory getDefault() {
-    if (defaultFactory == null) {
-      defaultFactory = new MouseMotionFactory();
+    if (defaultFactory.get() == null) {
+      defaultFactory.compareAndSet(null, new MouseMotionFactory());
     }
-    return defaultFactory;
+    return defaultFactory.get();
   }
 
   /**

--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * is available via getDefault(), but can create new instance via constructor.
  */
 public class MouseMotionFactory {
-  private static AtomicReference<MouseMotionFactory> defaultFactory = new AtomicReference<>();
+  private static final AtomicReference<MouseMotionFactory> defaultFactory = new AtomicReference<>();
   private MouseMotionNature nature;
   private Random random = new Random();
 

--- a/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/api/MouseMotionFactory.java
@@ -14,7 +14,7 @@ public class MouseMotionFactory {
   private MouseMotionNature nature;
   private Random random = new Random();
 
-  public MouseMotionFactory(final MouseMotionNature nature) {
+  public MouseMotionFactory(MouseMotionNature nature) {
     this.nature = nature;
   }
 
@@ -31,7 +31,7 @@ public class MouseMotionFactory {
    * (Mouse will be moved from its current position, not from the position
    * where mouse was during building.)
    */
-  public MouseMotion build(final int xDest, final int yDest) {
+  public MouseMotion build(int xDest, int yDest) {
     return new MouseMotion(nature, random, xDest, yDest);
   }
 
@@ -42,7 +42,7 @@ public class MouseMotionFactory {
    * @param yDest the end position y-coordinate for the mouse
    * @throws InterruptedException if something interrupts the thread.
    */
-  public void move(final int xDest, final int yDest) throws InterruptedException {
+  public void move(int xDest, int yDest) throws InterruptedException {
     build(xDest, yDest).move();
   }
 
@@ -72,7 +72,7 @@ public class MouseMotionFactory {
    *
    * @param systemCalls the systemcalls
    */
-  public void setSystemCalls(final SystemCalls systemCalls) {
+  public void setSystemCalls(SystemCalls systemCalls) {
     nature.setSystemCalls(systemCalls);
   }
 
@@ -90,7 +90,7 @@ public class MouseMotionFactory {
    *
    * @param deviationProvider the deviation provider
    */
-  public void setDeviationProvider(final DeviationProvider deviationProvider) {
+  public void setDeviationProvider(DeviationProvider deviationProvider) {
     nature.setDeviationProvider(deviationProvider);
   }
 
@@ -108,7 +108,7 @@ public class MouseMotionFactory {
    *
    * @param noiseProvider the noise provider
    */
-  public void setNoiseProvider(final NoiseProvider noiseProvider) {
+  public void setNoiseProvider(NoiseProvider noiseProvider) {
     nature.setNoiseProvider(noiseProvider);
   }
 
@@ -126,7 +126,7 @@ public class MouseMotionFactory {
    *
    * @param random the random
    */
-  public void setRandom(final Random random) {
+  public void setRandom(Random random) {
     this.random = random;
   }
 
@@ -144,7 +144,7 @@ public class MouseMotionFactory {
    *
    * @param mouseInfo the mouseInfo
    */
-  public void setMouseInfo(final MouseInfoAccessor mouseInfo) {
+  public void setMouseInfo(MouseInfoAccessor mouseInfo) {
     nature.setMouseInfo(mouseInfo);
   }
 
@@ -162,7 +162,7 @@ public class MouseMotionFactory {
    *
    * @param speedManager the manager
    */
-  public void setSpeedManager(final SpeedManager speedManager) {
+  public void setSpeedManager(SpeedManager speedManager) {
     nature.setSpeedManager(speedManager);
   }
 
@@ -180,7 +180,7 @@ public class MouseMotionFactory {
    *
    * @param nature the new nature
    */
-  public void setNature(final MouseMotionNature nature) {
+  public void setNature(MouseMotionNature nature) {
     this.nature = nature;
   }
 
@@ -189,7 +189,7 @@ public class MouseMotionFactory {
    *
    * @param manager the manager
    */
-  public void setOvershootManager(final OvershootManager manager) {
+  public void setOvershootManager(OvershootManager manager) {
     nature.setOvershootManager(manager);
   }
 

--- a/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
@@ -1,46 +1,45 @@
 package com.github.joonasvali.naturalmouse.support;
 
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
+
+import java.awt.*;
+import java.util.Random;
+
 import static com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER;
 import static com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER;
 
-import java.awt.AWTException;
-import java.awt.Robot;
-import java.util.Random;
-
-import com.github.joonasvali.naturalmouse.api.SystemCalls;
-
 public class DefaultMouseMotionNature extends MouseMotionNature {
 
-	public static final int TIME_TO_STEPS_DIVIDER = 8;
-	public static final int MIN_STEPS = 10;
-	public static final int EFFECT_FADE_STEPS = 15;
-	public static final int REACTION_TIME_BASE_MS = 20;
-	public static final int REACTION_TIME_VARIATION_MS = 120;
+  public static final int TIME_TO_STEPS_DIVIDER = 8;
+  public static final int MIN_STEPS = 10;
+  public static final int EFFECT_FADE_STEPS = 15;
+  public static final int REACTION_TIME_BASE_MS = 20;
+  public static final int REACTION_TIME_VARIATION_MS = 120;
 
-	public DefaultMouseMotionNature(final SystemCalls systemCalls) {
-		setSystemCalls(systemCalls);
-		setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
-		setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
-		setSpeedManager(new DefaultSpeedManager());
-		setOvershootManager(new DefaultOvershootManager(new Random()));
-		setEffectFadeSteps(EFFECT_FADE_STEPS);
-		setMinSteps(MIN_STEPS);
-		setMouseInfo(new DefaultMouseInfoAccessor());
-		setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
-		setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
-		setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
-	}
+  public DefaultMouseMotionNature(final SystemCalls systemCalls) {
+    setSystemCalls(systemCalls);
+    setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
+    setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
+    setSpeedManager(new DefaultSpeedManager());
+    setOvershootManager(new DefaultOvershootManager(new Random()));
+    setEffectFadeSteps(EFFECT_FADE_STEPS);
+    setMinSteps(MIN_STEPS);
+    setMouseInfo(new DefaultMouseInfoAccessor());
+    setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
+    setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
+    setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
+  }
 
-	public DefaultMouseMotionNature() {
-		this(new DefaultSystemCalls(getRobot()));
+  public DefaultMouseMotionNature() {
+    this(new DefaultSystemCalls(getRobot()));
 
-	}
+  }
 
-	private static Robot getRobot() {
-		try {
-			return new Robot();
-		} catch (final AWTException e) {
-			throw new RuntimeException(e);
-		}
-	}
+  private static Robot getRobot() {
+    try {
+      return new Robot();
+    } catch (final AWTException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
@@ -16,7 +16,7 @@ public class DefaultMouseMotionNature extends MouseMotionNature {
   public static final int REACTION_TIME_BASE_MS = 20;
   public static final int REACTION_TIME_VARIATION_MS = 120;
 
-  public DefaultMouseMotionNature(final SystemCalls systemCalls) {
+  public DefaultMouseMotionNature(SystemCalls systemCalls) {
     setSystemCalls(systemCalls);
     setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
     setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
@@ -32,7 +32,6 @@ public class DefaultMouseMotionNature extends MouseMotionNature {
 
   public DefaultMouseMotionNature() {
     this(new DefaultSystemCalls(getRobot()));
-
   }
 
   private static Robot getRobot() {

--- a/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
@@ -1,35 +1,46 @@
 package com.github.joonasvali.naturalmouse.support;
 
-import java.awt.*;
-import java.util.Random;
-
 import static com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER;
 import static com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER;
 
+import java.awt.AWTException;
+import java.awt.Robot;
+import java.util.Random;
+
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
+
 public class DefaultMouseMotionNature extends MouseMotionNature {
 
-  public static final int TIME_TO_STEPS_DIVIDER = 8;
-  public static final int MIN_STEPS = 10;
-  public static final int EFFECT_FADE_STEPS = 15;
-  public static final int REACTION_TIME_BASE_MS = 20;
-  public static final int REACTION_TIME_VARIATION_MS = 120;
+	public static final int TIME_TO_STEPS_DIVIDER = 8;
+	public static final int MIN_STEPS = 10;
+	public static final int EFFECT_FADE_STEPS = 15;
+	public static final int REACTION_TIME_BASE_MS = 20;
+	public static final int REACTION_TIME_VARIATION_MS = 120;
 
-  public DefaultMouseMotionNature() {
-    try {
-      setSystemCalls(new DefaultSystemCalls(new Robot()));
-    } catch (AWTException e) {
-      throw new RuntimeException(e);
-    }
+	public DefaultMouseMotionNature(final SystemCalls systemCalls) {
+		setSystemCalls(systemCalls);
+		setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
+		setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
+		setSpeedManager(new DefaultSpeedManager());
+		setOvershootManager(new DefaultOvershootManager(new Random()));
+		setEffectFadeSteps(EFFECT_FADE_STEPS);
+		setMinSteps(MIN_STEPS);
+		setMouseInfo(new DefaultMouseInfoAccessor());
+		setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
+		setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
+		setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
+	}
 
-    setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
-    setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
-    setSpeedManager(new DefaultSpeedManager());
-    setOvershootManager(new DefaultOvershootManager(new Random()));
-    setEffectFadeSteps(EFFECT_FADE_STEPS);
-    setMinSteps(MIN_STEPS);
-    setMouseInfo(new DefaultMouseInfoAccessor());
-    setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
-    setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
-    setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);
-  }
+	public DefaultMouseMotionNature() {
+		this(new DefaultSystemCalls(getRobot()));
+
+	}
+
+	private static Robot getRobot() {
+		try {
+			return new Robot();
+		} catch (final AWTException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/support/DefaultMouseMotionNature.java
@@ -1,5 +1,6 @@
 package com.github.joonasvali.naturalmouse.support;
 
+import com.github.joonasvali.naturalmouse.api.MouseInfoAccessor;
 import com.github.joonasvali.naturalmouse.api.SystemCalls;
 
 import java.awt.*;
@@ -17,6 +18,16 @@ public class DefaultMouseMotionNature extends MouseMotionNature {
   public static final int REACTION_TIME_VARIATION_MS = 120;
 
   public DefaultMouseMotionNature(SystemCalls systemCalls) {
+    this(systemCalls, new DefaultMouseInfoAccessor());
+  }
+
+  /**
+   * Create a default mouse motion nature with custom system calls and mouse info.
+   * Use this when running somewhere where java Robot does not work.
+   * @param systemCalls custom system calls to be used in the nature
+   * @param mouseInfoAccessor custom mouse info accessor to be used in the nature
+   */
+  public DefaultMouseMotionNature(SystemCalls systemCalls, MouseInfoAccessor mouseInfoAccessor) {
     setSystemCalls(systemCalls);
     setDeviationProvider(new SinusoidalDeviationProvider(DEFAULT_SLOPE_DIVIDER));
     setNoiseProvider(new DefaultNoiseProvider(DEFAULT_NOISINESS_DIVIDER));
@@ -24,7 +35,7 @@ public class DefaultMouseMotionNature extends MouseMotionNature {
     setOvershootManager(new DefaultOvershootManager(new Random()));
     setEffectFadeSteps(EFFECT_FADE_STEPS);
     setMinSteps(MIN_STEPS);
-    setMouseInfo(new DefaultMouseInfoAccessor());
+    setMouseInfo(mouseInfoAccessor);
     setReactionTimeBaseMs(REACTION_TIME_BASE_MS);
     setReactionTimeVariationMs(REACTION_TIME_VARIATION_MS);
     setTimeToStepsDivider(TIME_TO_STEPS_DIVIDER);

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -1,7 +1,12 @@
 package com.github.joonasvali.naturalmouse.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
 import com.github.joonasvali.naturalmouse.api.SpeedManager;
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
 import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider;
 import com.github.joonasvali.naturalmouse.support.DefaultOvershootManager;
@@ -11,166 +16,169 @@ import com.github.joonasvali.naturalmouse.support.Flow;
 import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
 import com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 public class FactoryTemplates {
-  /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
-   * Low speed, variating flow, lots of noise in movement.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createGrannyMotionFactory() {
-    return createGrannyMotionFactory(new DefaultMouseMotionNature());
-  }
+	/**
+	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
+	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createGrannyMotionFactory() {
+		return createGrannyMotionFactory(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
-   * Low speed, variating flow, lots of noise in movement.
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createGrannyMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.jaggedFlow()),
-        new Flow(FlowTemplates.random()),
-        new Flow(FlowTemplates.interruptedFlow()),
-        new Flow(FlowTemplates.interruptedFlow2()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.stoppingFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
-    factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
-    factory.getNature().setReactionTimeBaseMs(100);
+	/**
+	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
+	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createGrannyMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(
+				Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
+						new Flow(FlowTemplates.interruptedFlow()), new Flow(FlowTemplates.interruptedFlow2()),
+						new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.stoppingFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
+		factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
+		factory.getNature().setReactionTimeBaseMs(100);
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(3);
-    overshootManager.setMinDistanceForOvershoots(3);
-    overshootManager.setMinOvershootMovementMs(400);
-    overshootManager.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
-    overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(3);
+		overshootManager.setMinDistanceForOvershoots(3);
+		overshootManager.setMinOvershootMovementMs(400);
+		overshootManager
+				.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
+		overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
 
-    factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
-    manager.setMouseMovementBaseTimeMs(1000);
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+		factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
+		manager.setMouseMovementBaseTimeMs(1000);
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-  /**
-   * <h1>Robotic fluent movement.</h1>
-   * Custom speed, constant movement, no mistakes, no overshoots.
-   *
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
-   * @return the factory
-   */
-  public static MouseMotionFactory createDemoRobotMotionFactory(long motionTimeMsPer100Pixels) {
-    return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
-  }
+	/**
+	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+	 * mistakes, no overshoots.
+	 *
+	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+	 *                                 pixels of travelling
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createDemoRobotMotionFactory(final long motionTimeMsPer100Pixels) {
+		return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
+	}
 
-  /**
-   * <h1>Robotic fluent movement.</h1>
-   * Custom speed, constant movement, no mistakes, no overshoots.
-   *
-   * @param nature the nature for the template to be configured on
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
-   * @return the factory
-   */
-  public static MouseMotionFactory createDemoRobotMotionFactory(
-      MouseMotionNature nature, long motionTimeMsPer100Pixels
-  ) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final Flow flow = new Flow(FlowTemplates.constantSpeed());
-    double timePerPixel = motionTimeMsPer100Pixels / 100d;
-    SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
-    factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
-    factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
+	/**
+	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+	 * mistakes, no overshoots.
+	 *
+	 * @param nature                   the nature for the template to be configured
+	 *                                 on
+	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+	 *                                 pixels of travelling
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createDemoRobotMotionFactory(final MouseMotionNature nature,
+			final long motionTimeMsPer100Pixels) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final Flow flow = new Flow(FlowTemplates.constantSpeed());
+		final double timePerPixel = motionTimeMsPer100Pixels / 100d;
+		final SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
+		factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
+		factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(0);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(0);
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-  /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
-   * Quick movement, low noise, some deviation, lots of overshoots.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createFastGamerMotionFactory() {
-    return createFastGamerMotionFactory(new DefaultMouseMotionNature());
-  }
+	/**
+	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+	 * low noise, some deviation, lots of overshoots.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createFastGamerMotionFactory() {
+		return createFastGamerMotionFactory(new DefaultMouseMotionNature());
+	}
 
-  /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
-   * Quick movement, low noise, some deviation, lots of overshoots.
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createFastGamerMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.variatingFlow()),
-        new Flow(FlowTemplates.slowStartupFlow()),
-        new Flow(FlowTemplates.slowStartup2Flow()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.jaggedFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-    factory.getNature().setReactionTimeVariationMs(100);
-    manager.setMouseMovementBaseTimeMs(250);
+	/**
+	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+	 * low noise, some deviation, lots of overshoots.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createFastGamerMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
+				new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
+				new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.jaggedFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(
+				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+		factory.getNature().setReactionTimeVariationMs(100);
+		manager.setMouseMovementBaseTimeMs(250);
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(4);
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(4);
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
-  /**
-   * <h1>Standard computer user with average speed and movement mistakes</h1>
-   * medium noise, medium speed, medium noise and deviation.
-   *
-   * @return the factory
-   */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory() {
-    return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
-  }
-  /**
-   * <h1>Standard computer user with average speed and movement mistakes</h1>
-   * medium noise, medium speed, medium noise and deviation.
-   *
-   * @param nature the nature for the template to be configured on
-   * @return the factory
-   */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory(MouseMotionNature nature) {
-    MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(Arrays.asList(
-        new Flow(FlowTemplates.variatingFlow()),
-        new Flow(FlowTemplates.interruptedFlow()),
-        new Flow(FlowTemplates.interruptedFlow2()),
-        new Flow(FlowTemplates.slowStartupFlow()),
-        new Flow(FlowTemplates.slowStartup2Flow()),
-        new Flow(FlowTemplates.adjustingFlow()),
-        new Flow(FlowTemplates.jaggedFlow()),
-        new Flow(FlowTemplates.stoppingFlow())
-    ));
-    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-    factory.getNature().setReactionTimeVariationMs(110);
-    manager.setMouseMovementBaseTimeMs(400);
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 
-    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-    overshootManager.setOvershoots(4);
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory() {
+		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
+	}
 
-    factory.setSpeedManager(manager);
-    return factory;
-  }
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @param systemCalls System call provider
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory(final SystemCalls systemCalls) {
+		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
+	}
+
+	/**
+	 * <h1>Standard computer user with average speed and movement mistakes</h1>
+	 * medium noise, medium speed, medium noise and deviation.
+	 *
+	 * @param nature the nature for the template to be configured on
+	 * @return the factory
+	 */
+	public static MouseMotionFactory createAverageComputerUserMotionFactory(final MouseMotionNature nature) {
+		final MouseMotionFactory factory = new MouseMotionFactory(nature);
+		final List<Flow> flows = new ArrayList<>(
+				Arrays.asList(new Flow(FlowTemplates.variatingFlow()), new Flow(FlowTemplates.interruptedFlow()),
+						new Flow(FlowTemplates.interruptedFlow2()), new Flow(FlowTemplates.slowStartupFlow()),
+						new Flow(FlowTemplates.slowStartup2Flow()), new Flow(FlowTemplates.adjustingFlow()),
+						new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.stoppingFlow())));
+		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+		factory.setDeviationProvider(
+				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+		factory.getNature().setReactionTimeVariationMs(110);
+		manager.setMouseMovementBaseTimeMs(400);
+
+		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+		overshootManager.setOvershoots(4);
+
+		factory.setSpeedManager(manager);
+		return factory;
+	}
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -28,16 +28,14 @@ public class FactoryTemplates {
    */
   public static MouseMotionFactory createGrannyMotionFactory(MouseMotionNature nature) {
     MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(
-        Arrays.asList(
-            new Flow(FlowTemplates.jaggedFlow()),
-            new Flow(FlowTemplates.random()),
-            new Flow(FlowTemplates.interruptedFlow()),
-            new Flow(FlowTemplates.interruptedFlow2()),
-            new Flow(FlowTemplates.adjustingFlow()),
-            new Flow(FlowTemplates.stoppingFlow())
-        )
-    );
+    List<Flow> flows = new ArrayList<>(Arrays.asList(
+        new Flow(FlowTemplates.jaggedFlow()),
+        new Flow(FlowTemplates.random()),
+        new Flow(FlowTemplates.interruptedFlow()),
+        new Flow(FlowTemplates.interruptedFlow2()),
+        new Flow(FlowTemplates.adjustingFlow()),
+        new Flow(FlowTemplates.stoppingFlow())
+    ));
     DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
     factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
@@ -114,15 +112,13 @@ public class FactoryTemplates {
    */
   public static MouseMotionFactory createFastGamerMotionFactory(MouseMotionNature nature) {
     MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(
-        Arrays.asList(
-            new Flow(FlowTemplates.variatingFlow()),
-            new Flow(FlowTemplates.slowStartupFlow()),
-            new Flow(FlowTemplates.slowStartup2Flow()),
-            new Flow(FlowTemplates.adjustingFlow()),
-            new Flow(FlowTemplates.jaggedFlow())
-        )
-    );
+    List<Flow> flows = new ArrayList<>(Arrays.asList(
+        new Flow(FlowTemplates.variatingFlow()),
+        new Flow(FlowTemplates.slowStartupFlow()),
+        new Flow(FlowTemplates.slowStartup2Flow()),
+        new Flow(FlowTemplates.adjustingFlow()),
+        new Flow(FlowTemplates.jaggedFlow())
+    ));
     DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(
         new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
@@ -156,18 +152,16 @@ public class FactoryTemplates {
    */
   public static MouseMotionFactory createAverageComputerUserMotionFactory(MouseMotionNature nature) {
     MouseMotionFactory factory = new MouseMotionFactory(nature);
-    List<Flow> flows = new ArrayList<>(
-        Arrays.asList(
-            new Flow(FlowTemplates.variatingFlow()),
-            new Flow(FlowTemplates.interruptedFlow()),
-            new Flow(FlowTemplates.interruptedFlow2()),
-            new Flow(FlowTemplates.slowStartupFlow()),
-            new Flow(FlowTemplates.slowStartup2Flow()),
-            new Flow(FlowTemplates.adjustingFlow()),
-            new Flow(FlowTemplates.jaggedFlow()),
-            new Flow(FlowTemplates.stoppingFlow())
-        )
-    );
+    List<Flow> flows = new ArrayList<>(Arrays.asList(
+        new Flow(FlowTemplates.variatingFlow()),
+        new Flow(FlowTemplates.interruptedFlow()),
+        new Flow(FlowTemplates.interruptedFlow2()),
+        new Flow(FlowTemplates.slowStartupFlow()),
+        new Flow(FlowTemplates.slowStartup2Flow()),
+        new Flow(FlowTemplates.adjustingFlow()),
+        new Flow(FlowTemplates.jaggedFlow()),
+        new Flow(FlowTemplates.stoppingFlow())
+    ));
     DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(
         new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -2,7 +2,6 @@ package com.github.joonasvali.naturalmouse.util;
 
 import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
 import com.github.joonasvali.naturalmouse.api.SpeedManager;
-import com.github.joonasvali.naturalmouse.api.SystemCalls;
 import com.github.joonasvali.naturalmouse.support.*;
 
 import java.util.ArrayList;
@@ -146,17 +145,6 @@ public class FactoryTemplates {
    */
   public static MouseMotionFactory createAverageComputerUserMotionFactory() {
     return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
-  }
-
-  /**
-   * <h1>Standard computer user with average speed and movement mistakes</h1>
-   * medium noise, medium speed, medium noise and deviation.
-   *
-   * @param systemCalls System call provider
-   * @return the factory
-   */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory(SystemCalls systemCalls) {
-    return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
   }
 
   /**

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -27,7 +27,7 @@ public class FactoryTemplates {
    * @param nature the nature for the template to be configured on
    * @return the factory
    */
-  public static MouseMotionFactory createGrannyMotionFactory(final MouseMotionNature nature) {
+  public static MouseMotionFactory createGrannyMotionFactory(MouseMotionNature nature) {
     final MouseMotionFactory factory = new MouseMotionFactory(nature);
     final List<Flow> flows = new ArrayList<>(
         Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
@@ -43,7 +43,7 @@ public class FactoryTemplates {
     overshootManager.setMinDistanceForOvershoots(3);
     overshootManager.setMinOvershootMovementMs(400);
     overshootManager
-        .setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
+        .setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2f);
     overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
 
     factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
@@ -60,7 +60,7 @@ public class FactoryTemplates {
    *                                 pixels of travelling
    * @return the factory
    */
-  public static MouseMotionFactory createDemoRobotMotionFactory(final long motionTimeMsPer100Pixels) {
+  public static MouseMotionFactory createDemoRobotMotionFactory(long motionTimeMsPer100Pixels) {
     return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
   }
 
@@ -74,8 +74,8 @@ public class FactoryTemplates {
    *                                 pixels of travelling
    * @return the factory
    */
-  public static MouseMotionFactory createDemoRobotMotionFactory(final MouseMotionNature nature,
-                                                                final long motionTimeMsPer100Pixels) {
+  public static MouseMotionFactory createDemoRobotMotionFactory(MouseMotionNature nature,
+                                                                long motionTimeMsPer100Pixels) {
     final MouseMotionFactory factory = new MouseMotionFactory(nature);
     final Flow flow = new Flow(FlowTemplates.constantSpeed());
     final double timePerPixel = motionTimeMsPer100Pixels / 100d;
@@ -107,7 +107,7 @@ public class FactoryTemplates {
    * @param nature the nature for the template to be configured on
    * @return the factory
    */
-  public static MouseMotionFactory createFastGamerMotionFactory(final MouseMotionNature nature) {
+  public static MouseMotionFactory createFastGamerMotionFactory(MouseMotionNature nature) {
     final MouseMotionFactory factory = new MouseMotionFactory(nature);
     final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
         new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
@@ -143,7 +143,7 @@ public class FactoryTemplates {
    * @param systemCalls System call provider
    * @return the factory
    */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory(final SystemCalls systemCalls) {
+  public static MouseMotionFactory createAverageComputerUserMotionFactory(SystemCalls systemCalls) {
     return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
   }
 
@@ -154,13 +154,20 @@ public class FactoryTemplates {
    * @param nature the nature for the template to be configured on
    * @return the factory
    */
-  public static MouseMotionFactory createAverageComputerUserMotionFactory(final MouseMotionNature nature) {
+  public static MouseMotionFactory createAverageComputerUserMotionFactory(MouseMotionNature nature) {
     final MouseMotionFactory factory = new MouseMotionFactory(nature);
     final List<Flow> flows = new ArrayList<>(
-        Arrays.asList(new Flow(FlowTemplates.variatingFlow()), new Flow(FlowTemplates.interruptedFlow()),
-            new Flow(FlowTemplates.interruptedFlow2()), new Flow(FlowTemplates.slowStartupFlow()),
-            new Flow(FlowTemplates.slowStartup2Flow()), new Flow(FlowTemplates.adjustingFlow()),
-            new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.stoppingFlow())));
+        Arrays.asList(
+        		new Flow(FlowTemplates.variatingFlow()),
+						new Flow(FlowTemplates.interruptedFlow()),
+            new Flow(FlowTemplates.interruptedFlow2()),
+						new Flow(FlowTemplates.slowStartupFlow()),
+            new Flow(FlowTemplates.slowStartup2Flow()),
+						new Flow(FlowTemplates.adjustingFlow()),
+            new Flow(FlowTemplates.jaggedFlow()),
+						new Flow(FlowTemplates.stoppingFlow())
+				)
+		);
     final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(
         new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -1,184 +1,177 @@
 package com.github.joonasvali.naturalmouse.util;
 
+import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
+import com.github.joonasvali.naturalmouse.api.SpeedManager;
+import com.github.joonasvali.naturalmouse.api.SystemCalls;
+import com.github.joonasvali.naturalmouse.support.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
-import com.github.joonasvali.naturalmouse.api.SpeedManager;
-import com.github.joonasvali.naturalmouse.api.SystemCalls;
-import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
-import com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider;
-import com.github.joonasvali.naturalmouse.support.DefaultOvershootManager;
-import com.github.joonasvali.naturalmouse.support.DefaultSpeedManager;
-import com.github.joonasvali.naturalmouse.support.DoublePoint;
-import com.github.joonasvali.naturalmouse.support.Flow;
-import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
-import com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider;
-
 public class FactoryTemplates {
-	/**
-	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
-	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
-	 *
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createGrannyMotionFactory() {
-		return createGrannyMotionFactory(new DefaultMouseMotionNature());
-	}
+  /**
+   * <h1>Stereotypical granny using a computer with non-optical mouse from the
+   * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+   *
+   * @return the factory
+   */
+  public static MouseMotionFactory createGrannyMotionFactory() {
+    return createGrannyMotionFactory(new DefaultMouseMotionNature());
+  }
 
-	/**
-	 * <h1>Stereotypical granny using a computer with non-optical mouse from the
-	 * 90s.</h1> Low speed, variating flow, lots of noise in movement.
-	 *
-	 * @param nature the nature for the template to be configured on
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createGrannyMotionFactory(final MouseMotionNature nature) {
-		final MouseMotionFactory factory = new MouseMotionFactory(nature);
-		final List<Flow> flows = new ArrayList<>(
-				Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
-						new Flow(FlowTemplates.interruptedFlow()), new Flow(FlowTemplates.interruptedFlow2()),
-						new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.stoppingFlow())));
-		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-		factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
-		factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
-		factory.getNature().setReactionTimeBaseMs(100);
+  /**
+   * <h1>Stereotypical granny using a computer with non-optical mouse from the
+   * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+   *
+   * @param nature the nature for the template to be configured on
+   * @return the factory
+   */
+  public static MouseMotionFactory createGrannyMotionFactory(final MouseMotionNature nature) {
+    final MouseMotionFactory factory = new MouseMotionFactory(nature);
+    final List<Flow> flows = new ArrayList<>(
+        Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
+            new Flow(FlowTemplates.interruptedFlow()), new Flow(FlowTemplates.interruptedFlow2()),
+            new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.stoppingFlow())));
+    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+    factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
+    factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
+    factory.getNature().setReactionTimeBaseMs(100);
 
-		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-		overshootManager.setOvershoots(3);
-		overshootManager.setMinDistanceForOvershoots(3);
-		overshootManager.setMinOvershootMovementMs(400);
-		overshootManager
-				.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
-		overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
+    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    overshootManager.setOvershoots(3);
+    overshootManager.setMinDistanceForOvershoots(3);
+    overshootManager.setMinOvershootMovementMs(400);
+    overshootManager
+        .setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2);
+    overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
 
-		factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
-		manager.setMouseMovementBaseTimeMs(1000);
-		factory.setSpeedManager(manager);
-		return factory;
-	}
+    factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
+    manager.setMouseMovementBaseTimeMs(1000);
+    factory.setSpeedManager(manager);
+    return factory;
+  }
 
-	/**
-	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
-	 * mistakes, no overshoots.
-	 *
-	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
-	 *                                 pixels of travelling
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createDemoRobotMotionFactory(final long motionTimeMsPer100Pixels) {
-		return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
-	}
+  /**
+   * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+   * mistakes, no overshoots.
+   *
+   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+   *                                 pixels of travelling
+   * @return the factory
+   */
+  public static MouseMotionFactory createDemoRobotMotionFactory(final long motionTimeMsPer100Pixels) {
+    return createDemoRobotMotionFactory(new DefaultMouseMotionNature(), motionTimeMsPer100Pixels);
+  }
 
-	/**
-	 * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
-	 * mistakes, no overshoots.
-	 *
-	 * @param nature                   the nature for the template to be configured
-	 *                                 on
-	 * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
-	 *                                 pixels of travelling
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createDemoRobotMotionFactory(final MouseMotionNature nature,
-			final long motionTimeMsPer100Pixels) {
-		final MouseMotionFactory factory = new MouseMotionFactory(nature);
-		final Flow flow = new Flow(FlowTemplates.constantSpeed());
-		final double timePerPixel = motionTimeMsPer100Pixels / 100d;
-		final SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
-		factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
-		factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
+  /**
+   * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
+   * mistakes, no overshoots.
+   *
+   * @param nature                   the nature for the template to be configured
+   *                                 on
+   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
+   *                                 pixels of travelling
+   * @return the factory
+   */
+  public static MouseMotionFactory createDemoRobotMotionFactory(final MouseMotionNature nature,
+                                                                final long motionTimeMsPer100Pixels) {
+    final MouseMotionFactory factory = new MouseMotionFactory(nature);
+    final Flow flow = new Flow(FlowTemplates.constantSpeed());
+    final double timePerPixel = motionTimeMsPer100Pixels / 100d;
+    final SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
+    factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
+    factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
 
-		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-		overshootManager.setOvershoots(0);
+    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    overshootManager.setOvershoots(0);
 
-		factory.setSpeedManager(manager);
-		return factory;
-	}
+    factory.setSpeedManager(manager);
+    return factory;
+  }
 
-	/**
-	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
-	 * low noise, some deviation, lots of overshoots.
-	 *
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createFastGamerMotionFactory() {
-		return createFastGamerMotionFactory(new DefaultMouseMotionNature());
-	}
+  /**
+   * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+   * low noise, some deviation, lots of overshoots.
+   *
+   * @return the factory
+   */
+  public static MouseMotionFactory createFastGamerMotionFactory() {
+    return createFastGamerMotionFactory(new DefaultMouseMotionNature());
+  }
 
-	/**
-	 * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
-	 * low noise, some deviation, lots of overshoots.
-	 *
-	 * @param nature the nature for the template to be configured on
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createFastGamerMotionFactory(final MouseMotionNature nature) {
-		final MouseMotionFactory factory = new MouseMotionFactory(nature);
-		final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
-				new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
-				new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.jaggedFlow())));
-		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-		factory.setDeviationProvider(
-				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-		factory.getNature().setReactionTimeVariationMs(100);
-		manager.setMouseMovementBaseTimeMs(250);
+  /**
+   * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
+   * low noise, some deviation, lots of overshoots.
+   *
+   * @param nature the nature for the template to be configured on
+   * @return the factory
+   */
+  public static MouseMotionFactory createFastGamerMotionFactory(final MouseMotionNature nature) {
+    final MouseMotionFactory factory = new MouseMotionFactory(nature);
+    final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
+        new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
+        new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.jaggedFlow())));
+    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+    factory.setDeviationProvider(
+        new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+    factory.getNature().setReactionTimeVariationMs(100);
+    manager.setMouseMovementBaseTimeMs(250);
 
-		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-		overshootManager.setOvershoots(4);
+    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    overshootManager.setOvershoots(4);
 
-		factory.setSpeedManager(manager);
-		return factory;
-	}
+    factory.setSpeedManager(manager);
+    return factory;
+  }
 
-	/**
-	 * <h1>Standard computer user with average speed and movement mistakes</h1>
-	 * medium noise, medium speed, medium noise and deviation.
-	 *
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createAverageComputerUserMotionFactory() {
-		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
-	}
+  /**
+   * <h1>Standard computer user with average speed and movement mistakes</h1>
+   * medium noise, medium speed, medium noise and deviation.
+   *
+   * @return the factory
+   */
+  public static MouseMotionFactory createAverageComputerUserMotionFactory() {
+    return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
+  }
 
-	/**
-	 * <h1>Standard computer user with average speed and movement mistakes</h1>
-	 * medium noise, medium speed, medium noise and deviation.
-	 *
-	 * @param systemCalls System call provider
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createAverageComputerUserMotionFactory(final SystemCalls systemCalls) {
-		return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
-	}
+  /**
+   * <h1>Standard computer user with average speed and movement mistakes</h1>
+   * medium noise, medium speed, medium noise and deviation.
+   *
+   * @param systemCalls System call provider
+   * @return the factory
+   */
+  public static MouseMotionFactory createAverageComputerUserMotionFactory(final SystemCalls systemCalls) {
+    return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature(systemCalls));
+  }
 
-	/**
-	 * <h1>Standard computer user with average speed and movement mistakes</h1>
-	 * medium noise, medium speed, medium noise and deviation.
-	 *
-	 * @param nature the nature for the template to be configured on
-	 * @return the factory
-	 */
-	public static MouseMotionFactory createAverageComputerUserMotionFactory(final MouseMotionNature nature) {
-		final MouseMotionFactory factory = new MouseMotionFactory(nature);
-		final List<Flow> flows = new ArrayList<>(
-				Arrays.asList(new Flow(FlowTemplates.variatingFlow()), new Flow(FlowTemplates.interruptedFlow()),
-						new Flow(FlowTemplates.interruptedFlow2()), new Flow(FlowTemplates.slowStartupFlow()),
-						new Flow(FlowTemplates.slowStartup2Flow()), new Flow(FlowTemplates.adjustingFlow()),
-						new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.stoppingFlow())));
-		final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-		factory.setDeviationProvider(
-				new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
-		factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
-		factory.getNature().setReactionTimeVariationMs(110);
-		manager.setMouseMovementBaseTimeMs(400);
+  /**
+   * <h1>Standard computer user with average speed and movement mistakes</h1>
+   * medium noise, medium speed, medium noise and deviation.
+   *
+   * @param nature the nature for the template to be configured on
+   * @return the factory
+   */
+  public static MouseMotionFactory createAverageComputerUserMotionFactory(final MouseMotionNature nature) {
+    final MouseMotionFactory factory = new MouseMotionFactory(nature);
+    final List<Flow> flows = new ArrayList<>(
+        Arrays.asList(new Flow(FlowTemplates.variatingFlow()), new Flow(FlowTemplates.interruptedFlow()),
+            new Flow(FlowTemplates.interruptedFlow2()), new Flow(FlowTemplates.slowStartupFlow()),
+            new Flow(FlowTemplates.slowStartup2Flow()), new Flow(FlowTemplates.adjustingFlow()),
+            new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.stoppingFlow())));
+    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+    factory.setDeviationProvider(
+        new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+    factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
+    factory.getNature().setReactionTimeVariationMs(110);
+    manager.setMouseMovementBaseTimeMs(400);
 
-		final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
-		overshootManager.setOvershoots(4);
+    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    overshootManager.setOvershoots(4);
 
-		factory.setSpeedManager(manager);
-		return factory;
-	}
+    factory.setSpeedManager(manager);
+    return factory;
+  }
 }

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -28,17 +28,23 @@ public class FactoryTemplates {
    * @return the factory
    */
   public static MouseMotionFactory createGrannyMotionFactory(MouseMotionNature nature) {
-    final MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final List<Flow> flows = new ArrayList<>(
-        Arrays.asList(new Flow(FlowTemplates.jaggedFlow()), new Flow(FlowTemplates.random()),
-            new Flow(FlowTemplates.interruptedFlow()), new Flow(FlowTemplates.interruptedFlow2()),
-            new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.stoppingFlow())));
-    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+    MouseMotionFactory factory = new MouseMotionFactory(nature);
+    List<Flow> flows = new ArrayList<>(
+        Arrays.asList(
+            new Flow(FlowTemplates.jaggedFlow()),
+            new Flow(FlowTemplates.random()),
+            new Flow(FlowTemplates.interruptedFlow()),
+            new Flow(FlowTemplates.interruptedFlow2()),
+            new Flow(FlowTemplates.adjustingFlow()),
+            new Flow(FlowTemplates.stoppingFlow())
+        )
+    );
+    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(new SinusoidalDeviationProvider(9));
     factory.setNoiseProvider(new DefaultNoiseProvider(1.6));
     factory.getNature().setReactionTimeBaseMs(100);
 
-    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
     overshootManager.setOvershoots(3);
     overshootManager.setMinDistanceForOvershoots(3);
     overshootManager.setMinOvershootMovementMs(400);
@@ -76,14 +82,14 @@ public class FactoryTemplates {
    */
   public static MouseMotionFactory createDemoRobotMotionFactory(MouseMotionNature nature,
                                                                 long motionTimeMsPer100Pixels) {
-    final MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final Flow flow = new Flow(FlowTemplates.constantSpeed());
-    final double timePerPixel = motionTimeMsPer100Pixels / 100d;
-    final SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
+    MouseMotionFactory factory = new MouseMotionFactory(nature);
+    Flow flow = new Flow(FlowTemplates.constantSpeed());
+    double timePerPixel = motionTimeMsPer100Pixels / 100d;
+    SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
     factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
     factory.setNoiseProvider(((random, xStepSize, yStepSize) -> DoublePoint.ZERO));
 
-    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
     overshootManager.setOvershoots(0);
 
     factory.setSpeedManager(manager);
@@ -108,18 +114,24 @@ public class FactoryTemplates {
    * @return the factory
    */
   public static MouseMotionFactory createFastGamerMotionFactory(MouseMotionNature nature) {
-    final MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final List<Flow> flows = new ArrayList<>(Arrays.asList(new Flow(FlowTemplates.variatingFlow()),
-        new Flow(FlowTemplates.slowStartupFlow()), new Flow(FlowTemplates.slowStartup2Flow()),
-        new Flow(FlowTemplates.adjustingFlow()), new Flow(FlowTemplates.jaggedFlow())));
-    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+    MouseMotionFactory factory = new MouseMotionFactory(nature);
+    List<Flow> flows = new ArrayList<>(
+        Arrays.asList(
+            new Flow(FlowTemplates.variatingFlow()),
+            new Flow(FlowTemplates.slowStartupFlow()),
+            new Flow(FlowTemplates.slowStartup2Flow()),
+            new Flow(FlowTemplates.adjustingFlow()),
+            new Flow(FlowTemplates.jaggedFlow())
+        )
+    );
+    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(
         new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
     factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
     factory.getNature().setReactionTimeVariationMs(100);
     manager.setMouseMovementBaseTimeMs(250);
 
-    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
     overshootManager.setOvershoots(4);
 
     factory.setSpeedManager(manager);
@@ -155,27 +167,27 @@ public class FactoryTemplates {
    * @return the factory
    */
   public static MouseMotionFactory createAverageComputerUserMotionFactory(MouseMotionNature nature) {
-    final MouseMotionFactory factory = new MouseMotionFactory(nature);
-    final List<Flow> flows = new ArrayList<>(
+    MouseMotionFactory factory = new MouseMotionFactory(nature);
+    List<Flow> flows = new ArrayList<>(
         Arrays.asList(
-        		new Flow(FlowTemplates.variatingFlow()),
-						new Flow(FlowTemplates.interruptedFlow()),
+            new Flow(FlowTemplates.variatingFlow()),
+            new Flow(FlowTemplates.interruptedFlow()),
             new Flow(FlowTemplates.interruptedFlow2()),
-						new Flow(FlowTemplates.slowStartupFlow()),
+            new Flow(FlowTemplates.slowStartupFlow()),
             new Flow(FlowTemplates.slowStartup2Flow()),
-						new Flow(FlowTemplates.adjustingFlow()),
+            new Flow(FlowTemplates.adjustingFlow()),
             new Flow(FlowTemplates.jaggedFlow()),
-						new Flow(FlowTemplates.stoppingFlow())
-				)
-		);
-    final DefaultSpeedManager manager = new DefaultSpeedManager(flows);
+            new Flow(FlowTemplates.stoppingFlow())
+        )
+    );
+    DefaultSpeedManager manager = new DefaultSpeedManager(flows);
     factory.setDeviationProvider(
         new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
     factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
     factory.getNature().setReactionTimeVariationMs(110);
     manager.setMouseMovementBaseTimeMs(400);
 
-    final DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
+    DefaultOvershootManager overshootManager = (DefaultOvershootManager) factory.getOvershootManager();
     overshootManager.setOvershoots(4);
 
     factory.setSpeedManager(manager);

--- a/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
+++ b/src/main/java/com/github/joonasvali/naturalmouse/util/FactoryTemplates.java
@@ -2,7 +2,14 @@ package com.github.joonasvali.naturalmouse.util;
 
 import com.github.joonasvali.naturalmouse.api.MouseMotionFactory;
 import com.github.joonasvali.naturalmouse.api.SpeedManager;
-import com.github.joonasvali.naturalmouse.support.*;
+import com.github.joonasvali.naturalmouse.support.DefaultMouseMotionNature;
+import com.github.joonasvali.naturalmouse.support.DefaultNoiseProvider;
+import com.github.joonasvali.naturalmouse.support.DefaultOvershootManager;
+import com.github.joonasvali.naturalmouse.support.DefaultSpeedManager;
+import com.github.joonasvali.naturalmouse.support.DoublePoint;
+import com.github.joonasvali.naturalmouse.support.Flow;
+import com.github.joonasvali.naturalmouse.support.MouseMotionNature;
+import com.github.joonasvali.naturalmouse.support.SinusoidalDeviationProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,8 +17,8 @@ import java.util.List;
 
 public class FactoryTemplates {
   /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the
-   * 90s.</h1> Low speed, variating flow, lots of noise in movement.
+   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
+   * Low speed, variating flow, lots of noise in movement.
    *
    * @return the factory
    */
@@ -20,9 +27,8 @@ public class FactoryTemplates {
   }
 
   /**
-   * <h1>Stereotypical granny using a computer with non-optical mouse from the
-   * 90s.</h1> Low speed, variating flow, lots of noise in movement.
-   *
+   * <h1>Stereotypical granny using a computer with non-optical mouse from the 90s.</h1>
+   * Low speed, variating flow, lots of noise in movement.
    * @param nature the nature for the template to be configured on
    * @return the factory
    */
@@ -45,8 +51,7 @@ public class FactoryTemplates {
     overshootManager.setOvershoots(3);
     overshootManager.setMinDistanceForOvershoots(3);
     overshootManager.setMinOvershootMovementMs(400);
-    overshootManager
-        .setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2f);
+    overshootManager.setOvershootRandomModifierDivider(DefaultOvershootManager.OVERSHOOT_RANDOM_MODIFIER_DIVIDER / 2f);
     overshootManager.setOvershootSpeedupDivider(DefaultOvershootManager.OVERSHOOT_SPEEDUP_DIVIDER * 2);
 
     factory.getNature().setTimeToStepsDivider(DefaultMouseMotionNature.TIME_TO_STEPS_DIVIDER - 2);
@@ -56,11 +61,10 @@ public class FactoryTemplates {
   }
 
   /**
-   * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
-   * mistakes, no overshoots.
+   * <h1>Robotic fluent movement.</h1>
+   * Custom speed, constant movement, no mistakes, no overshoots.
    *
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
-   *                                 pixels of travelling
+   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
    * @return the factory
    */
   public static MouseMotionFactory createDemoRobotMotionFactory(long motionTimeMsPer100Pixels) {
@@ -68,19 +72,18 @@ public class FactoryTemplates {
   }
 
   /**
-   * <h1>Robotic fluent movement.</h1> Custom speed, constant movement, no
-   * mistakes, no overshoots.
+   * <h1>Robotic fluent movement.</h1>
+   * Custom speed, constant movement, no mistakes, no overshoots.
    *
-   * @param nature                   the nature for the template to be configured
-   *                                 on
-   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100
-   *                                 pixels of travelling
+   * @param nature the nature for the template to be configured on
+   * @param motionTimeMsPer100Pixels approximate time a movement takes per 100 pixels of travelling
    * @return the factory
    */
-  public static MouseMotionFactory createDemoRobotMotionFactory(MouseMotionNature nature,
-                                                                long motionTimeMsPer100Pixels) {
+  public static MouseMotionFactory createDemoRobotMotionFactory(
+      MouseMotionNature nature, long motionTimeMsPer100Pixels
+  ) {
     MouseMotionFactory factory = new MouseMotionFactory(nature);
-    Flow flow = new Flow(FlowTemplates.constantSpeed());
+    final Flow flow = new Flow(FlowTemplates.constantSpeed());
     double timePerPixel = motionTimeMsPer100Pixels / 100d;
     SpeedManager manager = distance -> new Pair<>(flow, (long) (timePerPixel * distance));
     factory.setDeviationProvider((totalDistanceInPixels, completionFraction) -> DoublePoint.ZERO);
@@ -94,8 +97,8 @@ public class FactoryTemplates {
   }
 
   /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
-   * low noise, some deviation, lots of overshoots.
+   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
+   * Quick movement, low noise, some deviation, lots of overshoots.
    *
    * @return the factory
    */
@@ -104,9 +107,8 @@ public class FactoryTemplates {
   }
 
   /**
-   * <h1>Gamer with fast reflexes and quick mouse movements.</h1> Quick movement,
-   * low noise, some deviation, lots of overshoots.
-   *
+   * <h1>Gamer with fast reflexes and quick mouse movements.</h1>
+   * Quick movement, low noise, some deviation, lots of overshoots.
    * @param nature the nature for the template to be configured on
    * @return the factory
    */
@@ -120,8 +122,7 @@ public class FactoryTemplates {
         new Flow(FlowTemplates.jaggedFlow())
     ));
     DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(
-        new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
     factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
     factory.getNature().setReactionTimeVariationMs(100);
     manager.setMouseMovementBaseTimeMs(250);
@@ -132,7 +133,6 @@ public class FactoryTemplates {
     factory.setSpeedManager(manager);
     return factory;
   }
-
   /**
    * <h1>Standard computer user with average speed and movement mistakes</h1>
    * medium noise, medium speed, medium noise and deviation.
@@ -142,7 +142,6 @@ public class FactoryTemplates {
   public static MouseMotionFactory createAverageComputerUserMotionFactory() {
     return createAverageComputerUserMotionFactory(new DefaultMouseMotionNature());
   }
-
   /**
    * <h1>Standard computer user with average speed and movement mistakes</h1>
    * medium noise, medium speed, medium noise and deviation.
@@ -163,8 +162,7 @@ public class FactoryTemplates {
         new Flow(FlowTemplates.stoppingFlow())
     ));
     DefaultSpeedManager manager = new DefaultSpeedManager(flows);
-    factory.setDeviationProvider(
-        new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
+    factory.setDeviationProvider(new SinusoidalDeviationProvider(SinusoidalDeviationProvider.DEFAULT_SLOPE_DIVIDER));
     factory.setNoiseProvider(new DefaultNoiseProvider(DefaultNoiseProvider.DEFAULT_NOISINESS_DIVIDER));
     factory.getNature().setReactionTimeVariationMs(110);
     manager.setMouseMovementBaseTimeMs(400);


### PR DESCRIPTION
The Robot class was previously initialized accidentally by static initializer of defaultFactory in MouseMotionFactory. Now the initialization is lazy when getDefault(..) is called. This should help to avoid error on system where Robot class initialization fails.

original contribution:
https://github.com/JoonasVali/NaturalMouseMotion/pull/12